### PR TITLE
Added xz compression mode to tar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,7 @@ $(PACKAGES_STAGE0_TAR_FILE): $(PORTS_DIR) $(PKGMK_CONFIG_FILE) $(PRTGET_CONFIG_F
 		( cd $$portdir && $(PKGMK_CMD) -d -cf $(PKGMK_CONFIG_FILE) $(PKGMK_CMD_OPTS) ) || exit 1; \
 	done
 	@echo "[`date +'%F %T'`] Creating $(PACKAGES_STAGE0_TAR_FILE)"
-	@tar cf $(PACKAGES_STAGE0_TAR_FILE) `find ports -type f -name "*.pkg.tar.$(PKGMK_COMPRESSION_MODE)"`
+	@tar cjf $(PACKAGES_STAGE0_TAR_FILE) `find ports -type f -name "*.pkg.tar.$(PKGMK_COMPRESSION_MODE)"`
 
 # Create a rootfs with stage0 packages
 .PHONY: build-stage0-rootfs
@@ -225,7 +225,7 @@ $(ROOTFS_STAGE0_TAR_FILE): $(PACKAGES_STAGE0_TAR_FILE) $(PRTGET_CONFIG_FILE) $(P
 	@echo "[`date +'%F %T'`] Installing hacks to avoid host dependencies"
 	@sudo ln -sf libnsl.so.3 $(ROOTFS_STAGE0_DIR)/usr/lib/libnsl.so.2
 	@echo "[`date +'%F %T'`] Creating $(ROOTFS_STAGE0_TAR_FILE)"
-	@cd $(ROOTFS_STAGE0_DIR) && sudo tar cf $(ROOTFS_STAGE0_TAR_FILE) *
+	@cd $(ROOTFS_STAGE0_DIR) && sudo tar cjf $(ROOTFS_STAGE0_TAR_FILE) *
 	@sudo chown $(CURRENT_UID):$(CURRENT_GID) $(ROOTFS_STAGE0_TAR_FILE)
 	@sudo rm -rf $(ROOTFS_STAGE0_DIR)
 
@@ -279,7 +279,7 @@ $(PACKAGES_STAGE1_TAR_FILE): $(PORTS_DIR) $(PKGMK_CONFIG_FILE) $(PRTGET_CONFIG_F
 			mv $(PORTS_STAGE1_PENDING_FILE).tmp  $(PORTS_STAGE1_PENDING_FILE); \
 	done
 	@echo "[`date +'%F %T'`] Creating $(PACKAGES_STAGE1_TAR_FILE)"
-	@tar cf $(PACKAGES_STAGE1_TAR_FILE) `find ports -type f -name "*.pkg.tar.$(PKGMK_COMPRESSION_MODE)"`
+	@tar cjf $(PACKAGES_STAGE1_TAR_FILE) `find ports -type f -name "*.pkg.tar.$(PKGMK_COMPRESSION_MODE)"`
 
 #------------------------------------------------------------------------------
 # STAGE0

--- a/Makefile
+++ b/Makefile
@@ -346,6 +346,7 @@ $(ROOTFS_STAGE1_TAR_FILE): $(ROOTFS_STAGE1_DIR)
 	@test ! -d $(ROOTFS_STAGE1_DIR)/workspace || sudo rmdir $(ROOTFS_STAGE1_DIR)/workspace
 	@sudo rm -f $(ROOTFS_STAGE1_DIR)/etc/pkgmk.conf
 	@sudo rm -f $(ROOTFS_STAGE1_DIR)/etc/prt-get.conf
+	@sudo rm -rf $(ROOTFS_STAGE1_DIR)/var/lib/pkg/rejected/*
 	@echo "[`date +'%F %T'`] Copying config files"
 	@sudo cp $(PORTS_DIR)/$(word 1, $(COLLECTIONS))/pkgutils/pkgmk.conf $(ROOTFS_STAGE1_DIR)/etc/pkgmk.conf
 	@sudo cp $(PORTS_DIR)/$(word 1, $(COLLECTIONS))/prt-get/prt-get.conf $(ROOTFS_STAGE1_DIR)/etc/prt-get.conf


### PR DESCRIPTION
If we want to let tar select the compression mode based on the file extension, we need to change the propposed change -j to -a