### PR TITLE
tools/overlay-diff: initial import

### DIFF
--- a/tools/overlay-diff
+++ b/tools/overlay-diff
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Order alphanum and extract two values from each line (port and version) 
+filter() {
+  cat - | sort -u | \
+  while read line; do
+    port=${line/:*/}; port=$(basename $(dirname ${port}))
+    version=${line/*:/}; version=${version/*=/}
+    echo "$port $version"
+  done
+}
+
+TMP_DIR=$(mktemp -d)
+PORTS_DIR=${PORTS_DIR:-ports}
+
+OVERLAY_COLLECTIONS="core-arm core-arm64"
+
+
+if [ ! -d ${PORTS_DIR} ]; then
+  echo "ERROR, ports directory can't be found at '$PORTS_DIR'"
+  exit 1
+fi
+
+grep -H '^version=' ports/core/*/Pkgfile 2>/dev/null | filter > ${TMP_DIR}/core.list
+for overlay in ${OVERLAY_COLLECTIONS}; do
+  grep -H '^version=' ports/${overlay}/*/Pkgfile 2>/dev/null | filter > ${TMP_DIR}/${overlay}.list
+done
+
+printf '%-20s %10s %30s\n' "PORT" "VERSION" "OVERLAY VERSION"
+while read port_name core_port_version; do
+  for overlay in ${OVERLAY_COLLECTIONS}; do
+    if grep "${port_name} " ${TMP_DIR}/${overlay}.list > ${TMP_DIR}/${overlay}.match; then
+      overlay_port_version=$(cut -d' ' -f2 ${TMP_DIR}/${overlay}.match)
+      #echo "DEBUG::: ${core_port_version} vs ${overlay_port_version}"
+      if [ "${core_port_version}" != "${overlay_port_version}" ]; then
+        printf '%-20s %10s %30s\n' "${port_name}" "${core_port_version}" "${overlay_port_version} (${overlay})"
+      fi
+    fi
+  done
+
+done < ${TMP_DIR}/core.list
+
+rm -rf ${TMP_DIR}


### PR DESCRIPTION
This script is a utility to compare the versions of the overlay ports we have (core-arm, core-arm64, ...) against the upstream versions in the official CRUX's core repo.

One use case is when we are building a new release and want to update our overlays to the version indicated by the git hash we used to clone the CRUX's core repo.

This is an example output:
```
$ tools/overlay-diff
PORT VERSION OVERLAY VERSION
bc 1.07.1 2.36 (core-arm)
binutils 2.39 2.35.2 (core-arm)
cmake 3.25.1 3.24.2 (core-arm)
libarchive 3.6.2 3.6.1 (core-arm)
make 4.4 3.24.2 (core-arm)
meson 0.64.1 0.63.2 (core-arm)
openssl 3.0.7 3.0.5 (core-arm)
python3 3.10.9 3.10.7 (core-arm)
```