### PR TITLE
Fix to be able to reuse stage0 from bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -327,15 +327,21 @@ stage1:
 #------------------------------------------------------------------------------
 # BOOSTRAP
 #
+# This target is designed to run stage0 and stage1 in order from a fresh state.
+# If stage0 has already been launched previously, bootstrap can reuse it, in
+# which case a warning message will be displayed warning that stage0 will be
+# reused to complete the bootstrap.
 #
 .PHONY: bootstrap
 bootstrap:
 	@echo "[`date +'%F %T'`] Bootstrap started"
 	@echo "[`date +'%F %T'`] Running Stage 0"
 	$(MAKE) stage0 2>&1 | tee stage0.log
-	@grep -e 'failed\.' -e 'succeeded\.' stage0.log
+	@if ! grep -e 'failed\.' -e 'succeeded\.' stage0.log; then \
+		echo "WARNING: stage0 has already been done before." && \
+		echo "WARNING: stage0 will be reused to continue the bootstrap process."; fi
 	@echo "[`date +'%F %T'`] Selecting $(ROOTFS_TAR_FILE) -> $(ROOTFS_STAGE0_TAR_FILE)"
-	@ln -s $(ROOTFS_STAGE0_TAR_FILE) $(ROOTFS_TAR_FILE)
+	@ln -sf $(ROOTFS_STAGE0_TAR_FILE) $(ROOTFS_TAR_FILE)
 	@echo "[`date +'%F %T'`] Running Stage 1"
 	$(MAKE) stage1 2>&1 | tee stage1.log
 	@grep -e 'failed\.' -e 'succeeded\.' stage1.log


### PR DESCRIPTION
One of the possible scenarios for using the Makefile, especially in the early stages of developing a new release, is to run `make stage0` as many times as necessary until all the ports succeed.

At this point, we could not launch the `make bootstrap` since it relies on the stage0.log and stage1.log files and when one of these did not exist or did not have what was expected it came out with an error, thus failing the `make bootstrap `.
In particular, this was not possible since we had a `grep` command that exited with error (exit 1) which breaks the make.

I have added a workaround so that instead of exiting with an error, it shows a warning that stage0 will be reused. But it is important to note that at this moment stage0.log and stage1.log files are useful only during bootstrap. 
For now this is a workaround enough for building a new release of crux-arm and help us a bit more but we should improve it to have better flow control between different stages and make each target idempotent.